### PR TITLE
Allow `getValue()` to return a nullable default value

### DIFF
--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -260,8 +260,8 @@ abstract class Update<T> {
 
   /// Gets the value if available (regardless of it is an optimistic one or not), else returns the
   /// result of [defaultValue].
-  T getValue({
-    @required T Function() defaultValue,
+  T? getValue({
+    @required T? Function() defaultValue,
   }) {
     assert(defaultValue != null);
     return mapValue(


### PR DESCRIPTION
Sometimes you don't want the default value to be of the type of the update element you're trying to fetch, and just want a null value if said element couldn't be retrieved to handle everything more easily through null checks. This commit is meant to address the current issue of not being able to _properly_ get a null as default value -- note the "properly", as actually nothing prevents you from passing a closure that returns null, but doing so confuses the linter and compiler into thinking the stored value from that method return can't be null while it actually is, incorrectly marking some null checks around it as unnecessary, and not warning you of forgotten checking