### PR TITLE
Use template argument to allow infering exception type

### DIFF
--- a/lib/src/update.dart
+++ b/lib/src/update.dart
@@ -354,8 +354,8 @@ abstract class Update<T> {
 
   /// Map the current error to a [K] value , if in a failure state. If so, the [error] method is called, else
   /// the [orElse] method is called.
-  K mapError<K>({
-    @required K Function(dynamic error, StackTrace stackTrace) error,
+  K mapError<K, E extends Exception>({
+    @required K Function(E error, StackTrace stackTrace) error,
     @required K Function() orElse,
   }) {
     assert(error != null);


### PR DESCRIPTION
Having a `dynamic` type for errors in the method `mapError(...)` can be cumbersome because in more precise handling cases you have to cast it in order to make the exception exploitable, which is awkward. This is commit is meant to address that issue by allowing to infer the error type

More commits on that subject may follow